### PR TITLE
Debug Overlay control node + scene

### DIFF
--- a/Scenes/Debug Overlay/debug_overlay.tscn
+++ b/Scenes/Debug Overlay/debug_overlay.tscn
@@ -1,0 +1,22 @@
+[gd_scene format=3 uid="uid://dp8gtvy4trdcf"]
+
+[node name="DebugOverlay" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Label" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 6.0
+offset_top = -34.0
+offset_right = 1152.0
+grow_vertical = 0
+theme_override_colors/font_color = Color(1, 1, 1, 0.8156863)
+theme_override_font_sizes/font_size = 24
+text = "Build 1.0"

--- a/project.godot
+++ b/project.godot
@@ -23,6 +23,7 @@ config/icon="res://Assets/Art/icon.svg"
 
 FmodManager="*res://addons/fmod/FmodManager.gd"
 DebugMenu="*res://Scripts/Singletons/DebugMenu.tscn"
+DebugOverlay="*res://Scenes/Debug Overlay/debug_overlay.tscn"
 
 [dotnet]
 


### PR DESCRIPTION
Control node and simple scene made for the debug overlay. The new scene was made global so that it doesn't have to be manually added to every level.