### PR TITLE
Fixing prototype map

### DIFF
--- a/Scenes/Levels/PrototypeLevel.tscn
+++ b/Scenes/Levels/PrototypeLevel.tscn
@@ -147,28 +147,28 @@ transform = Transform3D(2, 0, 0, 0, 1, 0, 0, 0, 1, 270, -3.335, 15)
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1.5, 175.00002, -3.335, 0)
 
 [node name="BasicFloor" parent="ObjectsGroup" instance=ExtResource("6_g047c")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 215, -3.335, -5)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 215, -3.335, 0.46022797)
 
 [node name="BasicFloor2" parent="ObjectsGroup" instance=ExtResource("6_g047c")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 215, -3.335, 5)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 215, -3.335, 10.460228)
 
 [node name="BasicFloor3" parent="ObjectsGroup" instance=ExtResource("6_g047c")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 235, -3.335, -5)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 235, -3.335, 0.46022797)
 
 [node name="BasicFloor4" parent="ObjectsGroup" instance=ExtResource("6_g047c")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 235, -3.335, 5)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 235, -3.335, 10.460228)
 
 [node name="BasicFloor5" parent="ObjectsGroup" instance=ExtResource("6_g047c")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 254.99998, -3.335, -5)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 254.99998, -3.335, 0.46022797)
 
 [node name="BasicFloor6" parent="ObjectsGroup" instance=ExtResource("6_g047c")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 254.99998, -3.335, 5)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 254.99998, -3.335, 10.460228)
 
 [node name="BasicFloor7" parent="ObjectsGroup" instance=ExtResource("6_g047c")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 274.99997, -3.335, -5)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 274.99997, -3.335, 0.46022797)
 
 [node name="BasicFloor8" parent="ObjectsGroup" instance=ExtResource("6_g047c")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 274.99997, -3.335, 5)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 274.99997, -3.335, 10.460228)
 
 [node name="Bus" parent="." instance=ExtResource("7_8cj62")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 49.8, 0, -2.5)


### PR DESCRIPTION
When adjusting the z-axis on the grayboxes, the prototype map ground was also shifted
- This branch just fixes the floors in the prototype map. 