### PR TITLE
Stomp boost applied correctly

### DIFF
--- a/Scenes/Ability Manager/StompAbility.tscn
+++ b/Scenes/Ability Manager/StompAbility.tscn
@@ -5,7 +5,8 @@
 [node name="StompAbility" type="Node"]
 script = ExtResource("1_3c3v0")
 stomp_speed = 10.0
-speed_boost_incrementor = 50.0
+speed_boost_factor = 100.0
+max_speed_boost = 100.0
 abilityType = 0
 
 [node name="StompSound" type="FmodEventEmitter3D" parent="."]

--- a/Scenes/Ability Manager/stomp_ability.gd
+++ b/Scenes/Ability Manager/stomp_ability.gd
@@ -5,10 +5,14 @@ class_name stomp_ability extends Ability
 ## Time it takes (in seconds) for the player to come to a stomp before getting sent downwards. CURRENTLY UNIMPLEMENTED
 @export var windup_time: float
 ## Amount to increase speed boost each second the player is falling
-@export var speed_boost_incrementor: float
+@export var speed_boost_factor: float
+## Maximum speed boost that can be provided by stomp
+@export var max_speed_boost: float
 
 ## Speed boost received from the stomp after stomp exits
 var player_speed_boost: float = 0.0
+## Player speed before using stomp
+var player_original_speed: float = 0.0
 ## Is stomp active?
 var is_active: bool = false
 
@@ -19,19 +23,22 @@ func Use(player: CharacterBody3D) -> void:
 	# Get just the xz-components of the player's velocity into a vector
 	var player_original_momentum := Vector2(player.velocity.x, player.velocity.z)
 	# Get the length of this vector and use it as the baseline for the speed boost
-	player_speed_boost = player_original_momentum.length()
+	player_original_speed = player_original_momentum.length()
 	# Send the player downwards
 	player.velocity = Vector3.DOWN * stomp_speed
 	stomp_sound.play()
 	is_active = true
-	set_process(true)
 	
 func Exit(_player: CharacterBody3D) -> void:
 	player_speed_boost = 0.0
+	player_original_speed = 0.0
 	is_active = false
-	
-func _ready() -> void:
-	set_process(false)
 
 func _process(delta: float) -> void:
-	player_speed_boost += speed_boost_incrementor * delta
+	# If set_process is false, then delta accumulates from the last _process to the next time
+	# set_process is true, so I need to keep process on but use a bool
+	if not is_active:
+		return
+	player_speed_boost += speed_boost_factor * delta
+	if player_speed_boost > max_speed_boost:
+		player_speed_boost = max_speed_boost

--- a/Scripts/DashAbility.gd
+++ b/Scripts/DashAbility.gd
@@ -22,7 +22,8 @@ func Use(player: CharacterBody3D):
 		my_player = player
 		# Get the players most recent directional input and their velocity
 		var newest_dir_input = Input.get_vector("move_left", "move_right", "move_up", "move_down")
-		var stored_momentum = player.velocity.length()
+		# Store the player's speed from before the dash and add in the boost from stomp
+		var stored_momentum = player.velocity.length() + speed_boost_from_stomp
 
 		var direction := (player.transform.basis * Vector3(newest_dir_input.x, 0, newest_dir_input.y)).normalized()
 		

--- a/Scripts/PlayerAbilityManager.gd
+++ b/Scripts/PlayerAbilityManager.gd
@@ -25,8 +25,7 @@ func _process(_delta: float) -> void:
 			
 	# Deactiveate stomp if player is on the ground
 	if $StompAbility.is_active and myPlayer.is_on_floor():
-		stomp_speed_boost = $StompAbility.player_speed_boost
-		print("Stomp speed boost: " + str(stomp_speed_boost))
+		stomp_speed_boost = $StompAbility.player_speed_boost + $StompAbility.player_original_speed
 		$StompAbility.Exit(myPlayer)
 		# Start the timer for the margin where dash receives the boost from stomp
 		$DashAndStompTimer.start(dash_and_stomp_margin)


### PR DESCRIPTION
Added an export variable which allows setting a cap to the stomp boost. This required adding some extra logic to ensure that the boost was applied _on top_ of the player's speed before starting the stomp