### PR TITLE
Minor code tweaks + export var changes

### DIFF
--- a/Scenes/Levels/PrototypeLevel.tscn
+++ b/Scenes/Levels/PrototypeLevel.tscn
@@ -15,13 +15,17 @@
 bank_paths = ["res://Assets/Sound_Banks/Master.strings.bank", "res://Assets/Sound_Banks/Master.bank"]
 
 [node name="LevelAudio" parent="." node_paths=PackedStringArray("player") instance=ExtResource("1_03jqj")]
-volume = 0.5
 player = NodePath("../Player")
 
 [node name="Player" parent="." instance=ExtResource("1_s5k85")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.197836, 3.335148, 0)
-friction = 5.0
-gravity = 40.0
+base_ramping_cap = 35.0
+base_acceleration = 40.0
+friction = 20.0
+stomp_speed = 30.0
+windup_duration = 0.15
+dash_duration = 0.5
+dash_cooldown = 0.5
 
 [node name="Camera3D" type="Camera3D" parent="Player"]
 transform = Transform3D(0.9958608, 0, 0, 0, -4.353046e-08, 0.9958608, 0, -0.9958608, -4.353046e-08, -0.44200003, 15, 0)

--- a/Scripts/player_controller.gd
+++ b/Scripts/player_controller.gd
@@ -64,12 +64,15 @@ func _on_dash_duration_timer_timeout() -> void:
 	acceleration = base_acceleration
 	ramping_cap = base_ramping_cap
 	max_speed = min(max_speed, ramping_cap)
+		#Commented out the below code as it caused some issues 
+		#when changing direction shortly after a dash.
+		#Keeping it here incase the removal of the code brings any issues
 	# Get xz-velocity unit vector and its length
-	var dir := Vector3(velocity.x, 0.0, velocity.z).normalized()
-	var speed = Vector3(velocity.x, 0.0, velocity.z).length()
+	#var dir := Vector3(velocity.x, 0.0, velocity.z).normalized()
+	#var speed = Vector3(velocity.x, 0.0, velocity.z).length()
 	# Lower xz-speed to the maximum if it exceeds it
-	velocity.x = min(dir.x * speed, dir.x * max_speed)
-	velocity.z = min(dir.z * speed, dir.z * max_speed)
+	#velocity.x = min(dir.x * speed, dir.x * max_speed)
+	#velocity.z = min(dir.z * speed, dir.z * max_speed)
 	$DashCooldownTimer.start()
 
 ## The states that the player can be in
@@ -148,7 +151,8 @@ func process_state(delta: float) -> void:
 			# Basing the decay off the player's initial speed ensures the glide lasts longer if the
 			# player is initially faster, but not too much longer
 			velocity = dir * speed_before_gliding * ratio
-			max_speed = max_speed_before_gliding * ratio 
+				#max_speed = max_speed_before_gliding * ratio 
+				#^Commented out because it made the glide very bad since it reduced max speed so drastically
 			handle_inputs(delta)
 			if is_on_wall():
 				crash()


### PR DESCRIPTION
Code changes:
-Gliding's speed decay no longer affects max speed 
-Exiting a dash no longer sets your velocity to its old value
	-old functionality would cause bugs where after a dash ends the player would be randomly sent in a different direction 	due to the value clamping of velocity when exiting dash
Export var changes:
-Increased max speed
-Increased acceleration and friction
-Reduced stomp windup time
-significantly increased stomp speed
-Dash cooldown reduced to 0.5 and dash length reduced to 0.5