### PR TITLE
Slope movement

### DIFF
--- a/Assets/Level Components/GrayboxeComponents/ramp.tscn
+++ b/Assets/Level Components/GrayboxeComponents/ramp.tscn
@@ -1,0 +1,20 @@
+[gd_scene load_steps=3 format=3 uid="uid://djjk6bqiwfll7"]
+
+[ext_resource type="Texture2D" uid="uid://b1pif7ph1u7ns" path="res://Assets/Art/GrayboxTemplateAssets/TopColor.jpg" id="1_kodhy"]
+
+[sub_resource type="ConvexPolygonShape3D" id="ConvexPolygonShape3D_b1s72"]
+points = PackedVector3Array(0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 0, 1, 1, 1, 1)
+
+[node name="ramp" type="StaticBody3D"]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.9016638, 0, -0.99968433)
+shape = SubResource("ConvexPolygonShape3D_b1s72")
+
+[node name="Sprite3D2" type="Sprite3D" parent="."]
+transform = Transform3D(0.56294185, 0, 0, 0, -2.653091e-08, -0.48860973, 0, 0.6069565, -2.135781e-08, 0.52021104, 0, -1.590136)
+texture = ExtResource("1_kodhy")
+
+[node name="Sprite3D" type="Sprite3D" parent="."]
+transform = Transform3D(1.0067443, 0, 0, 0, -2.1005947e-08, 1, 0, -0.48056006, -4.371139e-08, 0.055808544, 0, -0.49684364)
+texture = ExtResource("1_kodhy")

--- a/Scenes/Levels/slopeTest.tscn
+++ b/Scenes/Levels/slopeTest.tscn
@@ -1,0 +1,182 @@
+[gd_scene load_steps=13 format=3 uid="uid://crt8wwfuufnxn"]
+
+[ext_resource type="PackedScene" uid="uid://dcq1x56p7uigc" path="res://Scenes/Audio/level_audio.tscn" id="1_b1s72"]
+[ext_resource type="PackedScene" uid="uid://b7ey2vwyboxkp" path="res://Assets/Level Components/Obstacles/Vehicles/BusGrayBox01_playtest.tscn" id="2_d6c11"]
+[ext_resource type="PackedScene" uid="uid://c4cpjcdxo7dc2" path="res://Assets/Level Components/Obstacles/Floors/Road_Horizontal_Alpha.tscn" id="3_143vf"]
+[ext_resource type="PackedScene" uid="uid://bkojx8yxl0shy" path="res://Assets/Level Components/Obstacles/Buildings/BasicBuilding_Playtest.tscn" id="4_fhwgk"]
+[ext_resource type="PackedScene" uid="uid://rsvp8h0ufq0s" path="res://Assets/Level Components/Obstacles/Vehicles/car_playtest.tscn" id="5_8xvsj"]
+[ext_resource type="PackedScene" uid="uid://y5n5ec6cpnys" path="res://Assets/Level Components/Obstacles/Floors/Road_turn_Alpha.tscn" id="6_adamf"]
+[ext_resource type="PackedScene" uid="uid://507eva6q8tab" path="res://Assets/Level Components/Obstacles/Floors/Road_Vertical_Alpha.tscn" id="7_5uot6"]
+[ext_resource type="PackedScene" uid="uid://ke7hyaldhm05" path="res://Assets/Level Components/Obstacles/Vehicles/Bus_UP_playtest.tscn" id="8_085sq"]
+[ext_resource type="PackedScene" uid="uid://cp64vn3gfu61h" path="res://Assets/Level Components/Obstacles/Buildings/restaurant_Playtest.tscn" id="9_rlkbi"]
+[ext_resource type="PackedScene" uid="uid://chebxo65l0rlx" path="res://Assets/Level Components/Obstacles/Buildings/CornerBuilding_playtest.tscn" id="10_enjrx"]
+[ext_resource type="PackedScene" uid="uid://cfik16ilynn7l" path="res://Scenes/8D Movement/player.tscn" id="11_pbl64"]
+[ext_resource type="PackedScene" uid="uid://djjk6bqiwfll7" path="res://Assets/Level Components/GrayboxeComponents/ramp.tscn" id="12_d6c11"]
+
+[node name="DebugLevel2" type="Node3D"]
+
+[node name="FmodBankLoader" type="FmodBankLoader" parent="."]
+bank_paths = ["res://Assets/Sound_Banks/Master.strings.bank", "res://Assets/Sound_Banks/Master.bank"]
+
+[node name="LevelAudio" parent="." node_paths=PackedStringArray("player") instance=ExtResource("1_b1s72")]
+player = NodePath("../Player")
+
+[node name="Level terrian" type="Node3D" parent="."]
+transform = Transform3D(0.167, 0, 0, 0, 0.167, 0, 0, 0, 0.167, 0, 0, 0)
+
+[node name="Road2" parent="Level terrian" instance=ExtResource("3_143vf")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -42, 0, 0)
+
+[node name="Road" parent="Level terrian" instance=ExtResource("3_143vf")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 14, 0, 0)
+
+[node name="Road3" parent="Level terrian" instance=ExtResource("3_143vf")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 42, 0, 0)
+
+[node name="Road4" parent="Level terrian" instance=ExtResource("3_143vf")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 152.06104, 0, 0)
+
+[node name="Road10" parent="Level terrian" instance=ExtResource("3_143vf")]
+transform = Transform3D(-1, 0, -1.509958e-07, 0, 1, 0, 1.509958e-07, 0, -1, 261.49417, 0, -176.86394)
+
+[node name="Road16" parent="Level terrian" instance=ExtResource("3_143vf")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 312.9984, 0, -0.9825249)
+
+[node name="Road17" parent="Level terrian" instance=ExtResource("3_143vf")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 257.80542, 0, -0.9825249)
+
+[node name="Road11" parent="Level terrian" instance=ExtResource("3_143vf")]
+transform = Transform3D(-1, 0, -1.509958e-07, 0, 1, 0, 1.509958e-07, 0, -1, 316.43158, 0, -176.86394)
+
+[node name="Road5" parent="Level terrian" instance=ExtResource("3_143vf")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 96.69801, 0, 0)
+
+[node name="BusGrayBox01_playtest2" parent="Level terrian" instance=ExtResource("2_d6c11")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 90.87593, 0, 0)
+
+[node name="BusGrayBox01_playtest3" parent="Level terrian" instance=ExtResource("2_d6c11")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 225.86266, 0, -9.731606)
+
+[node name="BusGrayBox01_playtest4" parent="Level terrian" instance=ExtResource("2_d6c11")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 377.90613, 0, -110.857254)
+
+[node name="BusGrayBox01_playtest5" parent="Level terrian" instance=ExtResource("2_d6c11")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 359.4743, 0, -47.093292)
+
+[node name="BasicBuilding" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, -19.675, 15, -89.298)
+
+[node name="BasicBuilding2" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 34.357, 15, -89.298)
+
+[node name="BasicBuilding3" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 89.37, 15, -89.298)
+
+[node name="BasicBuilding4" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 144.188, 15, -89.298)
+
+[node name="BasicBuilding14" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 144.188, 14.9, -185.55)
+
+[node name="BasicBuilding12" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 416.654, 15, -145.2655)
+
+[node name="BasicBuilding15" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 416.654, 15, -53.769)
+
+[node name="BasicBuilding5" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 253.258, 15, -90.58)
+
+[node name="BasicBuilding8" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 277.238, 15, -257.622)
+
+[node name="BasicBuilding9" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 333.125, 15, -257.622)
+
+[node name="BasicBuilding11" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 389.527, 10, -257.622)
+
+[node name="BasicBuilding6" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 310.413, 15, -90.58)
+
+[node name="BasicBuilding13" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, -47.372, 15, 78.97372)
+
+[node name="BasicBuilding16" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 9.865562, 15, 78.97372)
+
+[node name="BasicBuilding17" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 65.01417, 15, 78.97372)
+
+[node name="BasicBuilding18" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 122.25172, 15, 78.97372)
+
+[node name="BasicBuilding19" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 178.65369, 15, 78.97372)
+
+[node name="BasicBuilding20" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 236.309, 15, 78.97372)
+
+[node name="BasicBuilding21" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 293.54657, 15, 78.97372)
+
+[node name="BasicBuilding22" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 350.36627, 15, 78.97372)
+
+[node name="BasicBuilding23" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 406.35, 15.2, 78.97372)
+
+[node name="BasicBuilding24" parent="Level terrian" instance=ExtResource("4_fhwgk")]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 414.288, 15.1, 27.277)
+
+[node name="CarRed2" parent="Level terrian" instance=ExtResource("5_8xvsj")]
+transform = Transform3D(1.8000001, 0, 0, 0, 0.25, 0, 0, 0, 1.6899998, 137.63763, 0.44361562, 8.711701)
+
+[node name="Road6" parent="Level terrian" instance=ExtResource("6_adamf")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 205.37755, 0, 0.26839733)
+
+[node name="Road15" parent="Level terrian" instance=ExtResource("6_adamf")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 369.2723, 0, -0.71112156)
+
+[node name="Road9" parent="Level terrian" instance=ExtResource("6_adamf")]
+transform = Transform3D(-1, 0, -1.509958e-07, 0, 1, 0, 1.509958e-07, 0, -1, 205.60326, 0, -177.14673)
+
+[node name="Road12" parent="Level terrian" instance=ExtResource("6_adamf")]
+transform = Transform3D(-4.371139e-08, 0, 1, 0, 1, 0, -1, 0, -4.371139e-08, 374.10773, 0, -172.53189)
+
+[node name="Road7" parent="Level terrian" instance=ExtResource("7_5uot6")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 205.21768, 0, -56.550728)
+
+[node name="Road8" parent="Level terrian" instance=ExtResource("7_5uot6")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 205.21768, 0, -111.851875)
+
+[node name="Road13" parent="Level terrian" instance=ExtResource("7_5uot6")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 369.08502, 0, -111.851875)
+
+[node name="Road14" parent="Level terrian" instance=ExtResource("7_5uot6")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 369.08502, 0, -57.229424)
+
+[node name="Bus_Up_playtest" parent="Level terrian" instance=ExtResource("8_085sq")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 196.3513, 0.00019531247, -58.08683)
+
+[node name="Bus_Up_playtest2" parent="Level terrian" instance=ExtResource("8_085sq")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 215.14322, 0.00019531247, -118.73338)
+
+[node name="BasicBuilding7" parent="Level terrian" instance=ExtResource("9_rlkbi")]
+transform = Transform3D(0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, 218.96155, -37.036617, -237.679)
+
+[node name="BasicBuilding10" parent="Level terrian" instance=ExtResource("10_enjrx")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 419.44308, 10, -265.798)
+
+[node name="ramp" parent="Level terrian" instance=ExtResource("12_d6c11")]
+transform = Transform3D(12, 0, 0, 0, 12, 0, 0, 0, 12, 43.489117, 0.000101611695, 1.6846904)
+
+[node name="Player" parent="." instance=ExtResource("11_pbl64")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -7.473543, 2.4012852, 0)
+floor_snap_length = 1.0
+
+[node name="Camera3D" type="Camera3D" parent="Player"]
+transform = Transform3D(0.9958608, 0, 0, 0, -4.353046e-08, 0.9958608, 0, -0.9958608, -4.353046e-08, -0.44200003, 15, 0)
+projection = 1
+size = 18.936
+near = 0.425

--- a/Scripts/player_controller.gd
+++ b/Scripts/player_controller.gd
@@ -76,7 +76,7 @@ func _on_dash_duration_timer_timeout() -> void:
 	$DashCooldownTimer.start()
 
 ## The states that the player can be in
-enum States{GROUND, COYOTE, AIR, STOMP_WINDUP, STOMP_FALL, GLIDE}
+enum States{GROUND, COYOTE, AIR, STOMP_WINDUP, STOMP_FALL, GLIDE, SLOPE}
 
 # Active values - may change during execution
 var max_speed: float = 0.0
@@ -116,19 +116,14 @@ func _physics_process(delta: float) -> void:
 ## Processes the current state. More complicated states have their own child nodes
 func process_state(delta: float) -> void:
 	match current_state:
-		States.GROUND:
+		States.GROUND, States.SLOPE:
 			# Ramping
 			if max_speed < ramping_cap: 
 				max_speed += pow(ramping_cap - max_speed, ramping_exponent) * delta
 			handle_inputs(delta)
 			if is_on_wall():
 				crash()
-		States.COYOTE:
-			fall(delta)
-			handle_inputs(delta)
-			if is_on_wall():
-				crash()
-		States.AIR:
+		States.COYOTE, States.AIR:
 			fall(delta)
 			handle_inputs(delta)
 			if is_on_wall():
@@ -171,6 +166,17 @@ func check_state_transitions() -> void:
 			elif not is_on_floor():
 				$CoyoteTimer.start()
 				transition_to(States.COYOTE)
+			elif get_floor_angle() != 0.0:
+				transition_to(States.SLOPE)
+		States.SLOPE:
+			if Input.is_action_just_pressed("move_jump"):
+				jump()
+				transition_to(States.AIR)
+			elif not is_on_floor():
+				$CoyoteTimer.start()
+				transition_to(States.COYOTE)
+			elif get_floor_angle() == 0.0:
+				transition_to(States.GROUND)
 		States.COYOTE:
 			if is_on_floor():
 				transition_to(States.GROUND)
@@ -204,8 +210,23 @@ func check_state_transitions() -> void:
 
 ## Actually changes the state, and maintains invariants for each state transition
 func transition_to(new_state: int) -> void:
-	# If a state transition must do the exact same thing regardless of the starting state,
-	# add it to this match statement
+	# Use this match statement to maintain invariants when leaving states
+	match current_state:
+		States.AIR:
+			# Restore friction when leaving the air
+			friction *= 2.0
+		States.GLIDE:
+			# Stop glide sound
+			$GlideSound.set_parameter("glide_state", "end")
+		States.STOMP_FALL:
+			$StompSound.set_parameter("stomp_state", "end")
+		States.SLOPE:
+			var angle: float = get_floor_angle()
+			# Sloped movement maintains the velocity but internally multiplies it by the angle,
+			# but by default this is not maintained when leaving the slope
+			velocity *= cos(angle)
+
+	# Use this match statement to maintain invariants when entering states
 	match new_state:
 		States.STOMP_WINDUP:
 			# If dash is active as stomp begins, end it
@@ -244,19 +265,10 @@ func transition_to(new_state: int) -> void:
 			# Lower friction in midair
 			friction /= 2.0
 		
-	# Use this match statement to maintain invariants when leaving states
-	match current_state:
-		States.AIR:
-			# Restore friction when leaving the air
-			friction *= 2.0
-		States.GLIDE:
-			# Stop glide sound
-			$GlideSound.set_parameter("glide_state", "end")
-		States.STOMP_FALL:
-			$StompSound.set_parameter("stomp_state", "end")
+	
 	
 	current_state = new_state
-	#print_state()
+	print_state()
 
 ## Handles inputs for standard movement and the dash
 func handle_inputs(delta: float) -> void:
@@ -364,3 +376,5 @@ func print_state() -> void:
 			print("Stomp")
 		States.GLIDE:
 			print("Glide")
+		States.SLOPE:
+			print("Slope")

--- a/project.godot
+++ b/project.godot
@@ -20,7 +20,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 
 config/name="Crowd Surfers V1.0"
 run/main_scene="uid://byy83xtygkpet"
-config/features=PackedStringArray("4.5", "Forward Plus")
+config/features=PackedStringArray("4.5", "C#", "Forward Plus")
 config/icon="res://Assets/Art/icon.svg"
 
 [autoload]


### PR DESCRIPTION
Simple slope movement. A basic slope graybox exists which is trivial to transform, and the player controller supports movement on it. A new state was added to support this.

Potential issue to watch out for: getting to the top of a slope transitions to the ground state (rather than coyote - even if no platform is provided at the top of the slope). I think this is because of the top edge of the slope which counts as ground. I doubt this will cause any problems but we shouldn't forget this