### PR TITLE
correct vehicle hitboxes

### DIFF
--- a/Assets/Level Components/Obstacles/Vehicles/BusGrayBox01_playtest.tscn
+++ b/Assets/Level Components/Obstacles/Vehicles/BusGrayBox01_playtest.tscn
@@ -1,29 +1,18 @@
-[gd_scene load_steps=4 format=3 uid="uid://b7ey2vwyboxkp"]
+[gd_scene load_steps=3 format=3 uid="uid://b7ey2vwyboxkp"]
 
 [ext_resource type="Texture2D" uid="uid://ci6yidjdojapt" path="res://Assets/Art/AlphaSprites/Bus 1 Down S3.png" id="1_gfknr"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_v4416"]
-size = Vector3(14, 2, 5.6341705)
-
-[sub_resource type="BoxShape3D" id="BoxShape3D_gfknr"]
-size = Vector3(0.17616367, 1, 0.054866552)
+size = Vector3(36.540108, 17.361322, 16.98241)
 
 [node name="BusGrayBox01_playtest" type="StaticBody3D" groups=["Metal"]]
-transform = Transform3D(0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, 5, 0, 0)
 
-[node name="ColllisionBody" type="StaticBody3D" parent="."]
-transform = Transform3D(-1.3113417e-05, 0, -300, 0, 0.04, 0, 300, 0, -1.3113417e-05, 0, 0, -4.5)
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="ColllisionBody"]
-transform = Transform3D(0.01, 0, 3.3861802e-15, 0, 24.999996, 0, -3.0531133e-16, 0, 0.01, 0.015936757, 24.999996, -0.0006360635)
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(-4.3711367e-08, 0, -1, 0, 1, 0, 1, 0, -4.3711367e-08, -0.25300014, 8.5, 3.213)
 shape = SubResource("BoxShape3D_v4416")
 debug_color = Color(1, 0, 0, 1)
 
-[node name="CollisionShape3DBack" type="CollisionShape3D" parent="ColllisionBody"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.002293555, 49.99, -0.00026857853)
-shape = SubResource("BoxShape3D_gfknr")
-debug_color = Color(0.8488591, 0.00090659084, 0.9013575, 1)
-
 [node name="Sprite3D" type="Sprite3D" parent="."]
-transform = Transform3D(-3, 2.6226823e-07, -1.146411e-14, 0, -4.3711395e-08, -0.9999998, -2.622673e-07, -3, 1.3113416e-07, 0.02845192, 2, -5.24)
+transform = Transform3D(-3, 4.5298742e-07, -6.600236e-15, 0, -1.3113416e-07, -1, -4.5298742e-07, -3, 4.371139e-08, 0, 17, -5.24)
+flip_h = true
 texture = ExtResource("1_gfknr")

--- a/Assets/Level Components/Obstacles/Vehicles/Bus_UP_playtest.tscn
+++ b/Assets/Level Components/Obstacles/Vehicles/Bus_UP_playtest.tscn
@@ -1,29 +1,18 @@
-[gd_scene load_steps=4 format=3 uid="uid://ke7hyaldhm05"]
+[gd_scene load_steps=3 format=3 uid="uid://ke7hyaldhm05"]
 
 [ext_resource type="Texture2D" uid="uid://b10hi3jxwakhy" path="res://Assets/Art/AlphaSprites/CS Vehicles S3/Bus 1 Up S3.png" id="1_8y6k3"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_v4416"]
-size = Vector3(13.311523, 2, 5.6341705)
-
-[sub_resource type="BoxShape3D" id="BoxShape3D_8y6k3"]
-size = Vector3(0.1619339, 1, 0.056793213)
+size = Vector3(36.560883, 12.589844, 17.330845)
 
 [node name="Bus_Up_playtest" type="StaticBody3D" groups=["Metal"]]
-transform = Transform3D(0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, 5, 0, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5, 0, 0)
 
-[node name="ColllisionBody" type="StaticBody3D" parent="."]
-transform = Transform3D(-1.3113417e-05, 0, -300, 0, 0.04, 0, 300, 0, -1.3113417e-05, 0, 0, -4.5)
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="ColllisionBody"]
-transform = Transform3D(0.01, 0, 3.3861802e-15, 0, 24.999996, 0, -3.0531133e-16, 0, 0.01, 0.011794038, 24.999996, -0.0006360635)
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(-4.3711356e-08, 0, -1, 0, 1, 0, 1, 0, -4.3711356e-08, 0.2521162, 6.1570606, 0.8728876)
 shape = SubResource("BoxShape3D_v4416")
 debug_color = Color(1, 0, 0, 1)
 
-[node name="CollisionShape3DBack" type="CollisionShape3D" parent="ColllisionBody"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.0026817303, 50, -0.0002593994)
-shape = SubResource("BoxShape3D_8y6k3")
-debug_color = Color(0.7932613, 0.071916185, 0.99999994, 1)
-
 [node name="Sprite3D" type="Sprite3D" parent="."]
-transform = Transform3D(-3, 2.6226823e-07, -1.146411e-14, 0, -4.3711395e-08, -0.9999998, -2.622673e-07, -3, 1.3113416e-07, 0.02845192, 2, -5.24)
+transform = Transform3D(-3, 4.5298742e-07, -6.600235e-15, 0, -1.3113416e-07, -0.9999998, -4.5298742e-07, -3, 4.371138e-08, 0, 12.5, -5.24)
 texture = ExtResource("1_8y6k3")

--- a/Assets/Level Components/Obstacles/Vehicles/car_playtest.tscn
+++ b/Assets/Level Components/Obstacles/Vehicles/car_playtest.tscn
@@ -3,19 +3,15 @@
 [ext_resource type="Texture2D" uid="uid://hra8lm37468s" path="res://Assets/Art/AlphaSprites/CS Vehicles S3/Car Red Side S3.png" id="1_52gxj"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_v4416"]
-size = Vector3(2.3566895, 5.5473633, 6.8542786)
+size = Vector3(11.658447, 4.131, 29.129108)
 
 [node name="CarRed" type="StaticBody3D" groups=["Metal"]]
-transform = Transform3D(1.8000001, 0, 0, 0, 0.25, 0, 0, 0, 1.6899998, 0, 0, 0)
 
-[node name="ColllisionBody" type="StaticBody3D" parent="."]
-transform = Transform3D(-1.3113417e-05, 0, -300, 0, 0.04, 0, 300, 0, -1.3113417e-05, 0, 0, -4.5)
-
-[node name="Sprite3D" type="Sprite3D" parent="ColllisionBody"]
-transform = Transform3D(-4.3710893e-10, -0.01, 4.3711387e-10, 0, -1.0927845e-06, -24.999996, 0.01, -4.3711373e-10, 1.9106851e-17, 0.0004999982, 24.999996, 5.551115e-17)
+[node name="Sprite3D" type="Sprite3D" parent="."]
+transform = Transform3D(-4, 6.039832e-07, -8.798114e-15, 0, -1.7484555e-07, -1.333, -6.039832e-07, -4, 5.826728e-08, 0, 4, -4.35)
 texture = ExtResource("1_52gxj")
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="ColllisionBody"]
-transform = Transform3D(0.01, 0, 1.37667655e-14, 0, 24.999996, 0, -8.326673e-17, 0, 0.01, 0.0027155746, -44.34203, -0.00021316661)
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 0.025899999, 2.0029411, -3.7233224)
 shape = SubResource("BoxShape3D_v4416")
 debug_color = Color(1, 0, 0, 1)

--- a/Scenes/Levels/M&R_PlaytestLvL.tscn
+++ b/Scenes/Levels/M&R_PlaytestLvL.tscn
@@ -132,10 +132,10 @@ transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 406.
 transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, 414.288, 15.1, 27.277)
 
 [node name="CarRed" parent="Level terrian" instance=ExtResource("6_vdeg2")]
-transform = Transform3D(1.8000001, 0, 0, 0, 0.25, 0, 0, 0, 1.6899998, 50.10437, 0.44361562, -8.9086485)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 47.453526, 0.44800138, -14.394943)
 
 [node name="CarRed2" parent="Level terrian" instance=ExtResource("6_vdeg2")]
-transform = Transform3D(1.8000001, 0, 0, 0, 0.25, 0, 0, 0, 1.6899998, 137.63763, 0.44361562, 8.711701)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 116.79594, 0.9589424, 8.779773)
 
 [node name="Road6" parent="Level terrian" instance=ExtResource("7_asgt7")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 205.37755, 0, 0.26839733)
@@ -175,6 +175,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 419.44308, 10, -265.798)
 
 [node name="Player" parent="." instance=ExtResource("1_v7xxd")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -7.473543, 2.4012852, 0)
+jump_speed = 16.0
 
 [node name="Camera3D" type="Camera3D" parent="Player"]
 transform = Transform3D(0.9958608, 0, 0, 0, -4.353046e-08, 0.9958608, 0, -0.9958608, -4.353046e-08, -0.44200003, 15, 0)

--- a/project.godot
+++ b/project.godot
@@ -20,7 +20,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 
 config/name="Crowd Surfers V1.0"
 run/main_scene="uid://byy83xtygkpet"
-config/features=PackedStringArray("4.5", "Forward Plus")
+config/features=PackedStringArray("4.5", "C#", "Forward Plus")
 config/icon="res://Assets/Art/icon.svg"
 
 [autoload]


### PR DESCRIPTION
All the vehicle hitboxes right now are far too low, which creates a mismatch between what the sprites look like and how the player actually interacts with them. This fix corrects the hitboxes to be consistent with the drawn sprites. Also slightly increased jump height in order to smoothly clear the now higher hitboxes.