### PR TITLE
Add Sidechain Compression

### DIFF
--- a/Support/FMOD_Project/Metadata/Event/{27b7de5d-f82c-481f-9fff-ddc140db93c6}.xml
+++ b/Support/FMOD_Project/Metadata/Event/{27b7de5d-f82c-481f-9fff-ddc140db93c6}.xml
@@ -56,7 +56,7 @@
 			<destination>{97fdd0b2-e7ed-4b55-ad3a-50884a997237}</destination>
 		</relationship>
 		<relationship name="output">
-			<destination>{42af6bb4-189a-466c-b82b-6ce3313b25c3}</destination>
+			<destination>{3edac7f7-8c55-4d16-9546-101a4e7cca52}</destination>
 		</relationship>
 	</object>
 	<object class="EventAutomatableProperties" id="{6290a373-7b94-4dc5-85e3-3a3db176bff3}" />

--- a/Support/FMOD_Project/Metadata/Event/{37e4c1ff-9cd4-4400-b1c5-8e6f4e784d62}.xml
+++ b/Support/FMOD_Project/Metadata/Event/{37e4c1ff-9cd4-4400-b1c5-8e6f4e784d62}.xml
@@ -53,7 +53,7 @@
 			<destination>{712a60d3-1b70-413e-95b0-0673ef0d8c56}</destination>
 		</relationship>
 		<relationship name="output">
-			<destination>{42af6bb4-189a-466c-b82b-6ce3313b25c3}</destination>
+			<destination>{35d6b6b7-1829-4fac-8138-9c69993f34b0}</destination>
 		</relationship>
 	</object>
 	<object class="EventAutomatableProperties" id="{b773aeda-a85b-4804-b774-f8234ffa917f}" />

--- a/Support/FMOD_Project/Metadata/Event/{786da779-c31c-46e0-8fd9-49dc9c0ed9f3}.xml
+++ b/Support/FMOD_Project/Metadata/Event/{786da779-c31c-46e0-8fd9-49dc9c0ed9f3}.xml
@@ -53,7 +53,7 @@
 			<destination>{dc4925e6-586b-4197-a2ef-5a038ba53c09}</destination>
 		</relationship>
 		<relationship name="output">
-			<destination>{42af6bb4-189a-466c-b82b-6ce3313b25c3}</destination>
+			<destination>{35d6b6b7-1829-4fac-8138-9c69993f34b0}</destination>
 		</relationship>
 	</object>
 	<object class="EventAutomatableProperties" id="{65744942-0149-4658-bd9e-b727042d090b}" />

--- a/Support/FMOD_Project/Metadata/Event/{8b651845-147a-42e7-ae53-406ca4e52e03}.xml
+++ b/Support/FMOD_Project/Metadata/Event/{8b651845-147a-42e7-ae53-406ca4e52e03}.xml
@@ -58,7 +58,7 @@
 			<destination>{767667fa-8973-4d4f-a551-4dcfc79d924e}</destination>
 		</relationship>
 		<relationship name="output">
-			<destination>{42af6bb4-189a-466c-b82b-6ce3313b25c3}</destination>
+			<destination>{bccac8f7-66e2-40a5-b42d-1f8ac4d6c315}</destination>
 		</relationship>
 	</object>
 	<object class="EventAutomatableProperties" id="{b0a85617-ee94-403f-8fef-9952825d2398}" />

--- a/Support/FMOD_Project/Metadata/Event/{ccf34438-e881-4f0c-92ef-2cdeb64532c8}.xml
+++ b/Support/FMOD_Project/Metadata/Event/{ccf34438-e881-4f0c-92ef-2cdeb64532c8}.xml
@@ -56,7 +56,7 @@
 			<destination>{d3a5cfe5-6a5a-4a03-910a-2f6afec9f32c}</destination>
 		</relationship>
 		<relationship name="output">
-			<destination>{42af6bb4-189a-466c-b82b-6ce3313b25c3}</destination>
+			<destination>{35d6b6b7-1829-4fac-8138-9c69993f34b0}</destination>
 		</relationship>
 	</object>
 	<object class="EventAutomatableProperties" id="{5a352760-f683-4cf6-ad75-e680c7f8b0b6}" />

--- a/Support/FMOD_Project/Metadata/Event/{dd67154c-6c88-45be-b2b1-39d11ce1a73d}.xml
+++ b/Support/FMOD_Project/Metadata/Event/{dd67154c-6c88-45be-b2b1-39d11ce1a73d}.xml
@@ -58,7 +58,7 @@
 			<destination>{3107c48e-6ed8-44a7-b276-ca366cbdd85c}</destination>
 		</relationship>
 		<relationship name="output">
-			<destination>{42af6bb4-189a-466c-b82b-6ce3313b25c3}</destination>
+			<destination>{3edac7f7-8c55-4d16-9546-101a4e7cca52}</destination>
 		</relationship>
 	</object>
 	<object class="EventAutomatableProperties" id="{44f18b1e-69ce-4bb5-8231-3a434303e2c1}" />
@@ -257,6 +257,7 @@
 	<object class="MixerBusEffectChain" id="{f47f0a8b-2b4a-4183-a1eb-c4641dd9783c}">
 		<relationship name="effects">
 			<destination>{9ebab3f8-e26e-4b9b-8b3d-9b350edb7805}</destination>
+			<destination>{84ad442e-07b9-4c4a-a9a3-198a758c16b3}</destination>
 		</relationship>
 	</object>
 	<object class="MixerBusPanner" id="{df51c6b2-caf7-40ec-aac6-a9d23fe19b1d}" />
@@ -325,6 +326,7 @@
 		</relationship>
 	</object>
 	<object class="MixerBusFader" id="{9ebab3f8-e26e-4b9b-8b3d-9b350edb7805}" />
+	<object class="Sidechain" id="{84ad442e-07b9-4c4a-a9a3-198a758c16b3}" />
 	<object class="AutomationCurve" id="{44157737-edbb-4f62-9afa-0571e9b51d7d}">
 		<relationship name="parameter">
 			<destination>{6cb37351-63b1-4789-b184-b8d27d886e42}</destination>

--- a/Support/FMOD_Project/Metadata/Group/{35d6b6b7-1829-4fac-8138-9c69993f34b0}.xml
+++ b/Support/FMOD_Project/Metadata/Group/{35d6b6b7-1829-4fac-8138-9c69993f34b0}.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<objects serializationModel="Studio.02.03.00">
+	<object class="MixerGroup" id="{35d6b6b7-1829-4fac-8138-9c69993f34b0}">
+		<property name="note">
+			<value>Sidechain drives a compressor with low attack and release</value>
+		</property>
+		<property name="name">
+			<value>Brief</value>
+		</property>
+		<relationship name="effectChain">
+			<destination>{d583cdc0-01b6-4d37-9a9f-24a4accdc354}</destination>
+		</relationship>
+		<relationship name="panner">
+			<destination>{ecd64175-aa16-4769-9bee-4a8610fe0d1b}</destination>
+		</relationship>
+		<relationship name="output">
+			<destination>{42af6bb4-189a-466c-b82b-6ce3313b25c3}</destination>
+		</relationship>
+	</object>
+	<object class="MixerBusEffectChain" id="{d583cdc0-01b6-4d37-9a9f-24a4accdc354}">
+		<relationship name="effects">
+			<destination>{43619bd4-3609-4554-bf4f-5353b713f94a}</destination>
+			<destination>{e6af0dfa-bec0-4742-b595-74aece198aa5}</destination>
+		</relationship>
+	</object>
+	<object class="MixerBusPanner" id="{ecd64175-aa16-4769-9bee-4a8610fe0d1b}" />
+	<object class="MixerBusFader" id="{43619bd4-3609-4554-bf4f-5353b713f94a}" />
+	<object class="Sidechain" id="{e6af0dfa-bec0-4742-b595-74aece198aa5}" />
+</objects>

--- a/Support/FMOD_Project/Metadata/Group/{3edac7f7-8c55-4d16-9546-101a4e7cca52}.xml
+++ b/Support/FMOD_Project/Metadata/Group/{3edac7f7-8c55-4d16-9546-101a4e7cca52}.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<objects serializationModel="Studio.02.03.00">
+	<object class="MixerGroup" id="{3edac7f7-8c55-4d16-9546-101a4e7cca52}">
+		<property name="note">
+			<value>Sidechain drives a compressor with low attack and high release</value>
+		</property>
+		<property name="name">
+			<value>Impacts</value>
+		</property>
+		<relationship name="effectChain">
+			<destination>{b3c5b910-ce91-4c66-9fca-4d64d584ee39}</destination>
+		</relationship>
+		<relationship name="panner">
+			<destination>{e51260e6-342b-4199-a352-263ce561da01}</destination>
+		</relationship>
+		<relationship name="output">
+			<destination>{42af6bb4-189a-466c-b82b-6ce3313b25c3}</destination>
+		</relationship>
+	</object>
+	<object class="MixerBusEffectChain" id="{b3c5b910-ce91-4c66-9fca-4d64d584ee39}">
+		<relationship name="effects">
+			<destination>{8267f79a-7fbc-4ef9-b5f6-05d2dcca3ab0}</destination>
+			<destination>{20633337-f909-4495-aa1b-62e88ba9e1d6}</destination>
+		</relationship>
+	</object>
+	<object class="MixerBusPanner" id="{e51260e6-342b-4199-a352-263ce561da01}" />
+	<object class="MixerBusFader" id="{8267f79a-7fbc-4ef9-b5f6-05d2dcca3ab0}" />
+	<object class="Sidechain" id="{20633337-f909-4495-aa1b-62e88ba9e1d6}" />
+</objects>

--- a/Support/FMOD_Project/Metadata/Group/{42af6bb4-189a-466c-b82b-6ce3313b25c3}.xml
+++ b/Support/FMOD_Project/Metadata/Group/{42af6bb4-189a-466c-b82b-6ce3313b25c3}.xml
@@ -17,10 +17,8 @@
 	<object class="MixerBusEffectChain" id="{9cd252f4-6a71-4aa6-8c60-20c9ecd68315}">
 		<relationship name="effects">
 			<destination>{278286ef-efcb-48ca-8ff5-b8256d4a2f4e}</destination>
-			<destination>{51577eb2-23f5-453a-8c37-9fb762da6005}</destination>
 		</relationship>
 	</object>
 	<object class="MixerBusPanner" id="{eadb3dd0-7db2-4b6c-b27a-7124d5bcb4ae}" />
 	<object class="MixerBusFader" id="{278286ef-efcb-48ca-8ff5-b8256d4a2f4e}" />
-	<object class="Sidechain" id="{51577eb2-23f5-453a-8c37-9fb762da6005}" />
 </objects>

--- a/Support/FMOD_Project/Metadata/Group/{4625d4ca-5e81-4ce1-be73-f1381128ad1e}.xml
+++ b/Support/FMOD_Project/Metadata/Group/{4625d4ca-5e81-4ce1-be73-f1381128ad1e}.xml
@@ -17,26 +17,56 @@
 	<object class="MixerBusEffectChain" id="{f28bb125-e030-40e2-b8b9-1c7d381455ca}">
 		<relationship name="effects">
 			<destination>{3414d699-709c-4dff-9164-15dfd09746e6}</destination>
-			<destination>{a7586562-a1e2-4720-9869-95cb16690142}</destination>
+			<destination>{e037bd5c-6458-432f-ae54-f3de654d44cc}</destination>
+			<destination>{52093678-3207-4829-8ff8-627ad8c1fbea}</destination>
+			<destination>{f3c58d1d-14c2-4657-a485-e87e55d38f94}</destination>
 		</relationship>
 	</object>
 	<object class="MixerBusPanner" id="{085f83bd-82a9-4861-a9cf-bdbd7bdf86de}" />
 	<object class="MixerBusFader" id="{3414d699-709c-4dff-9164-15dfd09746e6}" />
-	<object class="CompressorEffect" id="{a7586562-a1e2-4720-9869-95cb16690142}">
+	<object class="CompressorEffect" id="{e037bd5c-6458-432f-ae54-f3de654d44cc}">
 		<property name="threshold">
-			<value>-27.5</value>
+			<value>-35</value>
 		</property>
 		<property name="ratio">
-			<value>8.60000038</value>
+			<value>8.19999981</value>
 		</property>
 		<property name="attackTime">
 			<value>0.100000001</value>
 		</property>
 		<property name="releaseTime">
-			<value>58</value>
+			<value>66</value>
 		</property>
 		<relationship name="sidechains">
-			<destination>{51577eb2-23f5-453a-8c37-9fb762da6005}</destination>
+			<destination>{20633337-f909-4495-aa1b-62e88ba9e1d6}</destination>
+		</relationship>
+	</object>
+	<object class="CompressorEffect" id="{52093678-3207-4829-8ff8-627ad8c1fbea}">
+		<property name="threshold">
+			<value>-30</value>
+		</property>
+		<property name="attackTime">
+			<value>50</value>
+		</property>
+		<property name="releaseTime">
+			<value>1300</value>
+		</property>
+		<relationship name="sidechains">
+			<destination>{10c6ce6c-39d5-447f-ad67-7f19da00b7b2}</destination>
+		</relationship>
+	</object>
+	<object class="CompressorEffect" id="{f3c58d1d-14c2-4657-a485-e87e55d38f94}">
+		<property name="threshold">
+			<value>-32.5</value>
+		</property>
+		<property name="attackTime">
+			<value>0.100000001</value>
+		</property>
+		<property name="releaseTime">
+			<value>10</value>
+		</property>
+		<relationship name="sidechains">
+			<destination>{e6af0dfa-bec0-4742-b595-74aece198aa5}</destination>
 		</relationship>
 	</object>
 </objects>

--- a/Support/FMOD_Project/Metadata/Group/{bccac8f7-66e2-40a5-b42d-1f8ac4d6c315}.xml
+++ b/Support/FMOD_Project/Metadata/Group/{bccac8f7-66e2-40a5-b42d-1f8ac4d6c315}.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<objects serializationModel="Studio.02.03.00">
+	<object class="MixerGroup" id="{bccac8f7-66e2-40a5-b42d-1f8ac4d6c315}">
+		<property name="note">
+			<value>Sidechain drives a compressor with extremely high attack and release</value>
+		</property>
+		<property name="name">
+			<value>Glide</value>
+		</property>
+		<relationship name="effectChain">
+			<destination>{cebcf1f2-6f13-4713-8d40-d7be1ba75202}</destination>
+		</relationship>
+		<relationship name="panner">
+			<destination>{1d5622b6-7519-4def-a1fc-0f276a6d174c}</destination>
+		</relationship>
+		<relationship name="output">
+			<destination>{42af6bb4-189a-466c-b82b-6ce3313b25c3}</destination>
+		</relationship>
+	</object>
+	<object class="MixerBusEffectChain" id="{cebcf1f2-6f13-4713-8d40-d7be1ba75202}">
+		<relationship name="effects">
+			<destination>{fe578ebd-689d-4a43-806a-366dc2bec1e2}</destination>
+			<destination>{10c6ce6c-39d5-447f-ad67-7f19da00b7b2}</destination>
+		</relationship>
+	</object>
+	<object class="MixerBusPanner" id="{1d5622b6-7519-4def-a1fc-0f276a6d174c}" />
+	<object class="MixerBusFader" id="{fe578ebd-689d-4a43-806a-366dc2bec1e2}" />
+	<object class="Sidechain" id="{10c6ce6c-39d5-447f-ad67-7f19da00b7b2}" />
+</objects>


### PR DESCRIPTION
Added varying levels of sidechain compression
- Impacts (e.g. stomps) cause high compression ratio with low attack and medium release
- Glide causes compression with high attack and extremely high release
- Everything else causes compression with extremely low attack and release