### PR TITLE
Save system

### DIFF
--- a/Scenes/Levels/LevelOne.tscn
+++ b/Scenes/Levels/LevelOne.tscn
@@ -1456,6 +1456,7 @@ level_clear_ui = NodePath("../LevelClearUI")
 [node name="LevelClearUI" parent="." node_paths=PackedStringArray("hud_ui") instance=ExtResource("41_t6fm4")]
 visible = false
 hud_ui = NodePath("../Hud")
+level_number = 1
 
 [node name="PauseHolder" parent="." instance=ExtResource("42_5l05s")]
 

--- a/Scenes/Levels/lvl_concept_stage_2.tscn
+++ b/Scenes/Levels/lvl_concept_stage_2.tscn
@@ -101,6 +101,7 @@ level_clear_ui = NodePath("../LevelClearUI")
 [node name="LevelClearUI" parent="." node_paths=PackedStringArray("hud_ui") instance=ExtResource("19_7y7j4")]
 visible = false
 hud_ui = NodePath("../Hud")
+level_number = 2
 
 [node name="PauseHolder" parent="." instance=ExtResource("18_njsij")]
 visible = false

--- a/Scenes/UI Menus/Level_Clear.tscn
+++ b/Scenes/UI Menus/Level_Clear.tscn
@@ -38,12 +38,22 @@ text = "Level Clear!"
 [node name="ClearTimeText" type="Label" parent="Panel"]
 layout_mode = 0
 offset_left = 614.275
-offset_top = 2167.8608
+offset_top = 1928.8608
 offset_right = 1437.275
-offset_bottom = 2310.9897
+offset_bottom = 2071.9897
 scale = Vector2(8.974465, 8.747356)
 theme_override_font_sizes/font_size = 100
 text = "Clear Time: 00:00"
+
+[node name="BestTimeText" type="Label" parent="Panel"]
+layout_mode = 0
+offset_left = 614.275
+offset_top = 2798.5562
+offset_right = 1437.275
+offset_bottom = 2941.685
+scale = Vector2(8.974465, 8.747356)
+theme_override_font_sizes/font_size = 100
+text = "Best Time: 00:00"
 
 [node name="RestartButton" type="Button" parent="Panel"]
 layout_mode = 0

--- a/Scripts/Singletons/save_data_manager.gd
+++ b/Scripts/Singletons/save_data_manager.gd
@@ -1,0 +1,130 @@
+extends Node
+
+##Save data currently supports 3 levels, if you want to add more levels to the 
+##save data, just extend the array lengths, the save files should automatically adjust.
+##reducing the array size however may result in a crash on startup
+
+const SAVE_PATH = "user://savedata/data.save"
+
+##level index is (level number - 1)
+var levels_complete:Array[bool] = [false,false,false]
+var level_times:Array[float] = [0.0,0.0,0.0]
+##TBA when dialogues are added
+#var dialogues_reached:Array = []
+
+##If a save file exists, load it, otherwise create it
+func _ready() -> void:
+	if DirAccess.dir_exists_absolute(SAVE_PATH.get_base_dir()):
+		load_data()
+	else:
+		save_data()
+
+func save_data() -> void:
+	var saved_data: Dictionary = {
+		"levels": levels_complete,
+		"times": level_times,
+		"master_volume": Settings.master_volume,
+		"music_volume": Settings.music_volume,
+		"sfx_volume": Settings.sfx_volume
+	}
+	var err:Error = store_file(saved_data, SAVE_PATH)
+	if err != OK:
+		push_error("Unable to save data: ", error_string(err))
+	print("Save Data saved")
+
+func load_data() -> void:
+	var loaded_data: Dictionary = {}
+	
+	var err: Error = open_file(SAVE_PATH, loaded_data)
+	if err != OK:
+		push_error("Unable to load data: ", error_string(err))
+	
+	#copy over data, will result in an error if not copied like this
+	for i in range(loaded_data["levels"].size()):
+		levels_complete[i] = loaded_data["levels"][i]
+	for i in range(loaded_data["times"].size()):
+		level_times[i] = loaded_data["times"][i]
+	Settings.master_volume = loaded_data["master_volume"]
+	Settings.music_volume = loaded_data["music_volume"]
+	Settings.sfx_volume = loaded_data["sfx_volume"]
+	Settings.update_fmod_volumes()
+	print("Save Data loaded")
+
+
+
+#######################
+###  FILE HANDLING  ###
+#######################
+
+##Saves data
+static func store_file(data:Dictionary, file_path: String):
+	var result:Array = _open_file_for_write(file_path)
+	var err:Error = result[0] as Error
+	var file:FileAccess = result[1] as FileAccess
+	
+	#if we got an error return the error, otherwise save data
+	if err != OK:
+		return err;
+	
+	file.store_var(data, false)
+	file.close()
+	return OK
+
+##Loads data
+static func open_file(file_path: String, out_data: Dictionary) -> Error:
+	#clears out_data data, will be overridden
+	out_data.clear()
+	
+	var result:Array = _open_file_for_read(file_path)
+	var err:Error = result[0] as Error
+	var file:FileAccess = result[1] as FileAccess
+	#if we got an error opening the file return the error
+	if err != OK:
+		return err
+	
+	var value:Variant = file.get_var(false)
+	file.close()
+	
+	#return error if file data is not the right type
+	if typeof(value) != TYPE_DICTIONARY:
+		return ERR_INVALID_DATA
+	
+	#set out_data to the save data
+	out_data.merge(value as Dictionary, true)
+	return OK
+
+##Opens and reads file, for loading
+static func _open_file_for_read(path: String) -> Array:
+	#if file doesnt exist return file not found error
+	if not FileAccess.file_exists(path):
+		return [ERR_FILE_NOT_FOUND, null]
+	
+	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	#if file can't be read return access error
+	if file == null:
+		return [FileAccess.get_open_error(), null]
+	
+	return [OK, file]
+
+##Opens and edits file, for saving
+static func _open_file_for_write(file_path: String) -> Array:
+	var err: Error = _check_and_create_directory(file_path)
+	#if file wasn't accessible return error
+	if err != OK:
+		return [err, null]
+	
+	var file:FileAccess = FileAccess.open(file_path, FileAccess.WRITE)
+	#if file doesn't properly open return error
+	if file == null:
+		return [FileAccess.get_open_error(), null]
+		
+	return [OK, file]
+
+##Checks if save directory exists(where save files are stored), creates one if not and is able to
+static func _check_and_create_directory(file_path: String) -> Error:
+	var dir_path: String = file_path.get_base_dir()
+	#if file exists we good
+	if DirAccess.dir_exists_absolute(dir_path):
+		return OK
+	#if file doesn't exist and we can create we create it
+	return DirAccess.make_dir_recursive_absolute(dir_path)

--- a/Scripts/Singletons/save_data_manager.gd
+++ b/Scripts/Singletons/save_data_manager.gd
@@ -14,7 +14,7 @@ var level_times:Array[float] = [0.0,0.0,0.0]
 
 ##If a save file exists, load it, otherwise create it
 func _ready() -> void:
-	if DirAccess.dir_exists_absolute(SAVE_PATH.get_base_dir()):
+	if FileAccess.file_exists(SAVE_PATH):
 		load_data()
 	else:
 		save_data()

--- a/Scripts/Singletons/save_data_manager.gd.uid
+++ b/Scripts/Singletons/save_data_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://c1nrfb6bun34p

--- a/Scripts/level_clear.gd
+++ b/Scripts/level_clear.gd
@@ -1,8 +1,10 @@
 extends Control
 
 @export var hud_ui: Control
+@export var level_number: int
 
 @onready var clear_time_text: Label = $Panel/ClearTimeText
+@onready var best_time_text: Label = $Panel/BestTimeText
 
 func _ready() -> void:
 	process_mode = Node.PROCESS_MODE_WHEN_PAUSED
@@ -18,4 +20,14 @@ func _on_continue_button_pressed() -> void:
 	get_tree().paused = false
 
 func open_ui() -> void:
+	#don't adjust save file if not assigned
+	if level_number > 0:
+		SaveDataManager.levels_complete[level_number-1] = true
+		#level times being 0.0 means the level has no set time
+		if hud_ui.curr_Time < SaveDataManager.level_times[level_number-1] or SaveDataManager.level_times[level_number-1] == 0.0:
+			SaveDataManager.level_times[level_number-1] = hud_ui.curr_Time
+		SaveDataManager.save_data()
+		
 	clear_time_text.text = "Clear Time: " + hud_ui.get_Formatted_Timer_Text(hud_ui.curr_Time, false, false) + hud_ui.get_Formatted_Timer_Text(hud_ui.curr_Time, true, false)
+	if level_number > 0:
+		best_time_text.text = "Best Time: " + hud_ui.get_Formatted_Timer_Text(SaveDataManager.level_times[level_number-1], false, false) + hud_ui.get_Formatted_Timer_Text(SaveDataManager.level_times[level_number-1], true, false)

--- a/Scripts/main_menu.gd
+++ b/Scripts/main_menu.gd
@@ -56,6 +56,8 @@ func _on_settings_back_button_pressed() -> void:
 	
 	set_transitioning()
 	
+	SaveDataManager.save_data()
+	
 #Trigged by OrdersAnimationPlayer
 func set_orders_scene_visibility(new_visible: bool) -> void:
 	orders_scene.visible = new_visible

--- a/Scripts/pause_screen.gd
+++ b/Scripts/pause_screen.gd
@@ -47,6 +47,8 @@ func _on_settings_back_button_pressed() -> void:
 	transitioning = true
 	buttons_container.visible = true
 	phone_animation_player.play_backwards("open_settings")
+	
+	SaveDataManager.save_data()
 
 func _on_restart_level_button_pressed() -> void:
 	SceneFadeTransition.transition_to_scene(load(get_tree().current_scene.scene_file_path))

--- a/project.godot
+++ b/project.godot
@@ -31,6 +31,7 @@ PlayerSpawn="*res://Scripts/Singletons/Player_Spawn.gd"
 SceneFadeTransition="*res://Scripts/Singletons/scene_fade_transition.tscn"
 Settings="*res://Scripts/Singletons/settings.gd"
 Inky="*res://Scripts/Singletons/InkyHandler.cs"
+SaveDataManager="*res://Scripts/Singletons/save_data_manager.gd"
 
 [display]
 


### PR DESCRIPTION
Added a binary save system which keeps track of the volume variables, as well as whether or not act 1 or 2 were cleared and the best times for their levels

The save system is autoloaded and loads on startup. The game saves whenever you hit the back button on the saves menu(to save the settings) or complete act 1 or 2.

To have a levels time be saved, just set the level clear node to whatever level its in. Act 1s is set to level 1 Act 2s is set to level 2 etc.

Only saves for three levels are supported right now, if more is wanted just increase the array sizes in the save_data_manager script. The save files should automatically adjust to the change.

Reducing the array sizes or setting the level number in the level clear node to one higher than 3 will result in a crash so, don't do that.

Certain dialogues being reached is not currently tracked because those are not in the game yet. I can track them when implemented.

Features absent but likely desired:
- There is no clear save data function, if you want to delete your save file you need to go to %appdata%/Godot/app_userdata/Crowd Surfers V1.0/savedata. This is really easy to add and I will do so if requested.
- Save file verification. This will make the program not break if new stuff gets added to the save data. I can even have this verification update old save files so best times are kept throughout updates if requested.

I also added a best time score to the end scoreboard. It does not look good I just did it for debugging but I kept it since I figure people would like it.